### PR TITLE
Limiting autobinding to methods.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default ({types: t})=> ({
             for (const node of body.get('body')) {
                 if (node.isClassMethod({ kind: 'constructor' })) {
                     constructor = node
-                } else {
+                } else if (node.isClassMethod({ kind: 'method' })) {
                     methods.push(node.node.key)
                 }
             }


### PR DESCRIPTION
This prevents errors with ES7 getters and setters.

According to https://github.com/babel/babel/tree/master/packages/babel-types#classmethod, there are only four types to compare against.